### PR TITLE
improve docker testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 target
 .DS_Store
-testing/id_rsa*
-testing/gerrit_home

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,19 @@ services:
       - 8080:8080
       - 29418:29418
     volumes:
-      - ./:/root/src
+      - ./.git:/root/src.git:ro
+      - ./testing/data/src:/root/data/src
     environment:
       - USER_NAME=gerrit
       - USER_EMAIL=gerrit@localhost
       - WEBURL=http://localhost:8080
       - AUTH_TYPE=DEVELOPMENT_BECOME_ANY_ACCOUNT
-    
-      
+  bot:
+    build:
+      context: testing
+      dockerfile: Dockerfile.bot
+    volumes:
+      - .:/src:ro
+      - ./testing/data/target:/src/target
+    depends_on:
+      - gerrit

--- a/testing/Dockerfile.bot
+++ b/testing/Dockerfile.bot
@@ -1,0 +1,4 @@
+FROM rust
+RUN apt-get update && apt-get install -y build-essential cmake libssh2-1-dev
+RUN cargo install cargo-watch
+CMD ["/bin/bash", "/src/testing/bot.sh"]

--- a/testing/Dockerfile.bot
+++ b/testing/Dockerfile.bot
@@ -1,4 +1,7 @@
 FROM rust
-RUN apt-get update && apt-get install -y build-essential cmake libssh2-1-dev
+RUN apt-get update && \
+    apt-get install -y build-essential cmake libssh2-1-dev && \
+    rm -rf /var/lib/apt/lists/*
 RUN cargo install cargo-watch
-CMD ["/bin/bash", "/src/testing/bot.sh"]
+WORKDIR /src
+CMD cargo watch -s 'cargo run -- --config testing/config.yml'

--- a/testing/bot.sh
+++ b/testing/bot.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-echo "Building the bot ..."
-cd /src
-cargo build
-cargo watch -s 'cargo run -- --config testing/config.yml'

--- a/testing/bot.sh
+++ b/testing/bot.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+echo "Building the bot ..."
+cd /src
+cargo build
+cargo watch -s 'cargo run -- --config testing/config.yml'

--- a/testing/config.yml
+++ b/testing/config.yml
@@ -1,5 +1,5 @@
 gerrit:
-  hostname: localhost
+  hostname: gerrit
   port: 29418
   username: admin
   priv_key_path: testing/data/id_rsa
@@ -9,11 +9,11 @@ spark:
   bot_token: ""
   # optional, add a webhook URL is you want to register it automatically on Cisco Spark
   # webhook_url: "https://endpoint.example.org"
-  mode: 
+  mode:
     Direct:
       endpoint: "localhost:8888"
 
-  
+
 bot:
   msg_expiration: 4
   msg_capacity: 100

--- a/testing/data/.gitignore
+++ b/testing/data/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/testing/prepopulate.nohup
+++ b/testing/prepopulate.nohup
@@ -24,8 +24,7 @@ generate_ssh_key() {
   ssh -oStrictHostKeyChecking=no -p 29418 ${1}@localhost gerrit version
 
   echo "Copying the key with open permissions for everyone to use (uhuh)"
-  cp $HOME/.ssh/id_rsa* /root/src/testing/id_rsa
-  chmod 777 /root/src/testing/id_rsa*
+  install -m 777 $HOME/.ssh/id_rsa* /root/data
 }
 
 create_user() {
@@ -40,8 +39,10 @@ create_project() {
 
 push_git_repo() {
   echo "Cloning the repo before doing some stuff on it, for Gerrit!"
-  pushd $(mktemp -d)
-  git clone https://github.com/boxdot/gerritbot-rs .
+  rm -rf /root/data/src
+  mkdir /root/data/src
+  pushd /root/data/src
+  git clone file:///root/src.git .
   echo "Pushing repo to Gerrit"
   git remote add gerrit-test ssh://admin@localhost:29418/gerritbot-rs
   git checkout HEAD~1


### PR DESCRIPTION
Fix copying of SSH key.  Mount only git directory, not whole source, read-only.
Use that to initialize test project instead of github.  Create testdata
directory, mount only that writable.  Create second docker container to run
bot.  Run bot with 'cargo watch' to automatically recompile and restart on
changes.