### PR TITLE
Add case to handle when the WebEx webhook does not exist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "gerritbot"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/spark.rs
+++ b/src/spark.rs
@@ -307,7 +307,7 @@ impl WebClient {
         delete_with_token(&(self.url.clone() + "/webhooks/" + id), &self.bot_token)
             .map_err(Error::from)
             .and_then(|resp| {
-                if resp.status != hyper::status::StatusCode::NoContent {
+                if resp.status != hyper::status::StatusCode::NoContent && resp.status != hyper::status::StatusCode::NotFound {
                     Err(Error::DeleteWebhook(format!(
                         "Could not delete webhook: {}",
                         resp.status


### PR DESCRIPTION
When the program starts, it tries to delete the previous webhook,
the case where the webhook doesn't exist in the first place was
not covered, hence preventing startup.