### PR TITLE
improve lua handling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   gerrit:
-    image: openfrontier/gerrit:2.13.x
+    image: openfrontier/gerrit:2.14.x
     ports:
       - "127.0.0.1:8080:8080"
       - "127.0.0.1:29418:29418"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   gerrit:
     image: openfrontier/gerrit:2.13.x
     ports:
-      - 8080:8080
-      - 29418:29418
+      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:29418:29418"
     volumes:
       - ./.git:/root/src.git:ro
       - ./testing/data:/root/data

--- a/src/args.rs
+++ b/src/args.rs
@@ -21,7 +21,7 @@ pub struct Config {
     pub bot: BotConfig,
 }
 
-#[derive(Debug, Default, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct GerritConfig {
     pub host: String,
     pub username: String,
@@ -54,15 +54,6 @@ pub enum ModeConfig {
 pub struct BotConfig {
     pub msg_expiration: u64,
     pub msg_capacity: usize,
-}
-
-impl Default for BotConfig {
-    fn default() -> Self {
-        Self {
-            msg_expiration: 60,
-            msg_capacity: 100,
-        }
-    }
 }
 
 const USAGE: &str = "

--- a/src/args.rs
+++ b/src/args.rs
@@ -54,6 +54,7 @@ pub enum ModeConfig {
 pub struct BotConfig {
     pub msg_expiration: u64,
     pub msg_capacity: usize,
+    pub format_script: Option<String>,
 }
 
 const USAGE: &str = "

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,12 @@ fn main() {
             Duration::from_secs(config.bot.msg_expiration),
         );
     };
+    if let Some(format_script) = config.bot.format_script {
+        bot.set_format_script(format_script).unwrap_or_else(|err| {
+            error!("Failed to set format script: {:?}", err);
+            std::process::exit(1);
+        });
+    }
 
     // event loop
     let mut core = tokio_core::reactor::Core::new().unwrap();

--- a/testing/config.yml
+++ b/testing/config.yml
@@ -1,6 +1,5 @@
 gerrit:
-  hostname: gerrit
-  port: 29418
+  host: localhost:29418
   username: admin
   priv_key_path: testing/data/id_rsa
 
@@ -9,10 +8,11 @@ spark:
   bot_token: ""
   # optional, add a webhook URL is you want to register it automatically on Cisco Spark
   # webhook_url: "https://endpoint.example.org"
+  output_mode: Console
   mode:
     Direct:
       endpoint: "localhost:8888"
-
+      output: Spark
 
 bot:
   msg_expiration: 4

--- a/testing/prepopulate.nohup
+++ b/testing/prepopulate.nohup
@@ -17,7 +17,7 @@ generate_ssh_key() {
   fi
 
   echo -n "Uploading SSH public-key to Gerrit user ${1}: "
-  curl -s --digest --user admin:secret -X POST --url "http://localhost:8080/a/accounts/${1}/sshkeys" --data-binary "@${ssh_key}.pub"
+  curl -s --user admin:secret -X POST --url "http://localhost:8080/a/accounts/${1}/sshkeys" --data-binary "@${ssh_key}.pub"
 
   echo -n "Test if connection works: "
   ssh -i ${ssh_key} -o StrictHostKeyChecking=no -p 29418 ${1}@localhost gerrit version
@@ -29,13 +29,13 @@ generate_ssh_key() {
 
 create_user() {
   echo -n "Creating user $1: "
-  curl -s --digest --user admin:secret -X PUT --url "http://localhost:8080/a/accounts/${1}" -H "Content-Type: application/json" --data "{\"name\": \"$1\", \"email\": \"$2\"}"
+  curl -s --user admin:secret -X PUT --url "http://localhost:8080/a/accounts/${1}" -H "Content-Type: application/json" --data "{\"name\": \"$1\", \"email\": \"$2\"}"
   generate_ssh_key $1 "_$1"
 }
 
 create_project() {
   echo -n "Creating project $1: "
-  curl -s --digest --user admin:secret -X PUT --url "http://localhost:8080/a/projects/${1}"
+  curl -s --user admin:secret -X PUT --url "http://localhost:8080/a/projects/${1}"
 }
 
 push_git_repo() {


### PR DESCRIPTION
Change the way the Lua formatting script is handled.  Instead of a
separate file that needs to live somewhere relative to the working
directory of the bot the format script is now just part of the
configuration.  It can be given as an in-line value in YAML like so:

```yaml
  bot:
    msg_expiration: 4
    msg_capacity: 100
    format_script:
      function main(event)
          return "there was an event"
      end
```

The "format_script" key is optional however and if it isn't present the
value is taken from the scripts/format.Lua file.  That file however is
baked in at compile time.  There is now a syntax check that will fail
the bot startup if the Lua cannot be parsed or the main function is
missing.  On any other error detected at run-time panics in the
formatting will now produce an error message instead of a panic.

Fixes #46