### PR TITLE
start improving tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,8 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "shellexpand 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spectral 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "speculate 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stderrlog 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1373,6 +1375,22 @@ version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "spectral"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "speculate"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ssh2"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,6 +1444,16 @@ dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2018,6 +2046,8 @@ dependencies = [
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
+"checksum spectral 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
+"checksum speculate 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bad2613a3c69816ecbe014b0d048d7c1181a9513005642986885d5a27ed6b62a"
 "checksum ssh2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "dee822d619a700f98c4de3b5931f272ecc7cf2e924ceb2df47b61df4ae033a0c"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum stderrlog 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "61dc66b7ae72b65636dbf36326f9638fb3ba27871bb737a62e2c309b87d91b70"
@@ -2025,6 +2055,7 @@ dependencies = [
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "3d0760c312538987d363c36c42339b55f5ee176ea8808bbe4543d484a291c8d1"
 "checksum structopt-derive 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "528aeb7351d042e6ffbc2a6fb76a86f9b622fdf7c25932798e7a82cb03bc94c6"
+"checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"

--- a/gerritbot-spark/src/lib.rs
+++ b/gerritbot-spark/src/lib.rs
@@ -20,7 +20,9 @@ mod sqs;
 /// Define a newtype String.
 macro_rules! newtype_string {
     ($type_name:ident, $type_ref_name:ident) => {
-        #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[derive(
+            Deserialize, Serialize, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash,
+        )]
         #[serde(transparent)]
         pub struct $type_name(String);
 
@@ -195,6 +197,24 @@ pub struct Message {
     markdown: Option<String>,
     html: Option<String>,
     files: Option<Vec<String>>,
+}
+
+impl Message {
+    /// Create a simple message for use in tests.
+    pub fn test_message(person_email: Email, person_id: PersonId, text: String) -> Self {
+        Self {
+            person_email,
+            person_id,
+            text,
+            created: None,
+            room_id: Default::default(),
+            room_type: RoomType::Direct,
+            html: None,
+            files: None,
+            id: Default::default(),
+            markdown: None,
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]

--- a/gerritbot/Cargo.toml
+++ b/gerritbot/Cargo.toml
@@ -23,3 +23,8 @@ serde_yaml = "0.8"
 shellexpand = "0.1"
 stderrlog = "0.4"
 tokio = "0.1"
+
+[dev-dependencies]
+speculate = "0.1"
+spectral = { version = "0.6", default-features = false }
+

--- a/gerritbot/tests/test_command.rs
+++ b/gerritbot/tests/test_command.rs
@@ -1,0 +1,109 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use futures::{future, stream, Future};
+use lazy_static::lazy_static;
+
+use spectral::prelude::*;
+use speculate::speculate;
+
+use gerritbot_spark as spark;
+use spark::{EmailRef, PersonId, PersonIdRef};
+
+use gerritbot::*;
+
+#[derive(Debug, Clone, Default)]
+struct TestGerritCommandRunner;
+impl GerritCommandRunner for TestGerritCommandRunner {}
+
+#[derive(Debug, Clone)]
+struct Reply {
+    person_id: PersonId,
+    message: String,
+}
+
+type Replies = Rc<RefCell<Vec<Reply>>>;
+
+#[derive(Debug, Clone, Default)]
+struct TestSparkClient {
+    replies: Replies,
+}
+
+impl SparkClient for TestSparkClient {
+    type ReplyFuture = future::FutureResult<(), spark::Error>;
+    fn reply(&self, person_id: &PersonId, msg: &str) -> Self::ReplyFuture {
+        self.replies.borrow_mut().push(Reply {
+            person_id: person_id.to_owned(),
+            message: msg.to_string(),
+        });
+        future::ok(())
+    }
+}
+
+type TestBot = Bot<TestGerritCommandRunner, TestSparkClient>;
+
+lazy_static! {
+    static ref TEST_PERSON_ID: &'static PersonIdRef = PersonIdRef::new("test_person_id");
+    static ref TEST_PERSON_EMAIL: &'static EmailRef = EmailRef::new("test@person.test");
+}
+
+trait TestBotTrait: Sized {
+    fn new() -> (Self, Replies);
+    fn send_message(self, message: &str);
+    fn send_messages(self, messages: &[&str]);
+}
+
+impl TestBotTrait for TestBot {
+    fn new() -> (Self, Replies) {
+        let replies = Replies::default();
+        let bot = Builder::new(State::new()).build(
+            Default::default(),
+            TestSparkClient {
+                replies: replies.clone(),
+            },
+        );
+        (bot, replies)
+    }
+
+    fn send_messages(self, messages: &[&str]) {
+        let spark_messages = stream::iter_ok(messages.iter().map(|msg| {
+            spark::Message::test_message(
+                TEST_PERSON_EMAIL.to_owned(),
+                TEST_PERSON_ID.to_owned(),
+                msg.to_string(),
+            )
+        }));
+        let gerrit_events = stream::empty();
+        self.run(gerrit_events, spark_messages).wait().unwrap();
+    }
+
+    fn send_message(self, message: &str) {
+        self.send_messages(&[message][..]);
+    }
+}
+
+speculate! {
+    before {
+        let (bot, replies) = TestBot::new();
+    }
+
+    describe "command tests" {
+        test "status" {
+            bot.send_message("status");
+            let replies = Rc::try_unwrap(replies).unwrap().into_inner();
+            assert_that!(replies).has_length(1);
+            assert_that!(replies[0].person_id).is_equal_to(TEST_PERSON_ID.to_owned());
+            assert_that!(replies[0].message).contains("disabled");
+        }
+
+        test "enable then status" {
+            bot.send_messages(&["enable", "status"][..]);
+            let replies = Rc::try_unwrap(replies).unwrap().into_inner();
+            assert_that!(replies).has_length(2);
+            assert_that!(replies[0].person_id).is_equal_to(TEST_PERSON_ID.to_owned());
+            assert_that!(replies[0].message).contains("Happy reviewing!");
+            assert_that!(replies[1].person_id).is_equal_to(TEST_PERSON_ID.to_owned());
+            assert_that!(replies[1].message).contains("enabled");
+        }
+    }
+}

--- a/gerritbot/tests/test_command.rs
+++ b/gerritbot/tests/test_command.rs
@@ -105,5 +105,13 @@ speculate! {
             assert_that!(replies[1].person_id).is_equal_to(TEST_PERSON_ID.to_owned());
             assert_that!(replies[1].message).contains("enabled");
         }
+
+        test "unknown command" {
+            bot.send_message("this is not a known command");
+            let replies = Rc::try_unwrap(replies).unwrap().into_inner();
+            assert_that!(replies).has_length(1);
+            assert_that!(replies[0].person_id).is_equal_to(TEST_PERSON_ID.to_owned());
+            assert_that!(replies[0].message).contains("I am GerritBot");
+        }
     }
 }


### PR DESCRIPTION
Use `spectral` and `speculate` to enable writing unit tests with fixtures and (hopefully) more readable assertions.  Not all of the existing tests are converted yet.  Add an integration test that uses a mock spark client to send messages and checks for responses.