### PR TITLE
fix inline comments

### DIFF
--- a/gerritbot/src/lib.rs
+++ b/gerritbot/src/lib.rs
@@ -454,10 +454,10 @@ pub fn request_extended_gerrit_info(event: &gerrit::Event) -> Cow<'static, [gerr
     let owner = &event.change.owner.username;
     let approver = event.author.as_ref().map(|user| &user.username);
     let is_human = approver
-        .map(|name| name.to_lowercase().contains("bot"))
+        .map(|name| !name.to_lowercase().contains("bot"))
         .unwrap_or(false);
 
-    if Some(owner) != approver && is_human && has_inline_comments(event) {
+    if Some(owner) != approver && is_human && maybe_has_inline_comments(event) {
         Cow::Borrowed(&[gerrit::ExtendedInfo::InlineComments])
     } else {
         Cow::Borrowed(&[])
@@ -512,10 +512,10 @@ where
         }
         Action::UpdateApprovals(event) => {
             self.get_approvals_msg(&event).map(|(user, message, _is_human)|
-                if has_inline_comments(&event) {
+                if definitely_has_inline_comments(&event) {
                     Task::Reply(Response::new(
-                        user.spark_person_id.clone()
-                        , format_msg_with_comments(message, event.change)))
+                        user.spark_person_id.clone(),
+                        format_msg_with_comments(message, event.change, event.patchset)))
                 } else {
                     Task::Reply(Response::new(user.spark_person_id.clone(), message))
                 })
@@ -807,7 +807,7 @@ where
         if !msgs.is_empty() {
             // We got some approvals
             Some((&self.state.users[user_pos], msgs.join("\n\n"), is_human)) // two newlines since it is markdown
-        } else if is_human && has_inline_comments(&event) && event.comment.is_some() {
+        } else if is_human && definitely_has_inline_comments(&event) && event.comment.is_some() {
             // We did not get any approvals, but we got inline comments from a human.
             Some((
                 &self.state.users[user_pos],
@@ -940,7 +940,9 @@ const HELP_MSG: &str = r#"Commands:
 This project is open source, feel free to help us at: https://github.com/boxdot/gerritbot-rs
 "#;
 
-fn has_inline_comments(event: &gerrit::Event) -> bool {
+/// Guess if the change might have comments by looking for a specially formatted
+/// comment.
+fn maybe_has_inline_comments(event: &gerrit::Event) -> bool {
     lazy_static! {
         static ref RE: Regex = Regex::new(r"\(\d+\scomments?\)").unwrap();
     }
@@ -951,15 +953,22 @@ fn has_inline_comments(event: &gerrit::Event) -> bool {
         .unwrap_or(false)
 }
 
-fn format_comments(change: gerrit::Change) -> Option<String> {
+fn definitely_has_inline_comments(event: &gerrit::Event) -> bool {
+    event
+        .patchset
+        .comments
+        .as_ref()
+        .map(|c| !c.is_empty())
+        .unwrap_or(false)
+}
+
+fn format_comments(change: gerrit::Change, patchset: gerrit::PatchSet) -> Option<String> {
     let change_number = change.number;
     let host = change.url.split('/').nth(2).unwrap();
+    let patch_set_number = patchset.number;
 
-    change.current_patch_set.map(|patch_set| {
-        let patch_set_number = patch_set.number;
-        let mut comments = patch_set.comments.unwrap_or_else(Vec::new);
+    patchset.comments.map(|mut comments| {
         comments.sort_by(|a, b| a.file.cmp(&b.file));
-
         comments
             .into_iter()
             .group_by(|c| c.file.clone())
@@ -995,8 +1004,12 @@ fn format_comments(change: gerrit::Change) -> Option<String> {
     })
 }
 
-fn format_msg_with_comments(message: String, change: gerrit::Change) -> String {
-    if let Some(additional_message) = format_comments(change) {
+fn format_msg_with_comments(
+    message: String,
+    change: gerrit::Change,
+    patchset: gerrit::PatchSet,
+) -> String {
+    if let Some(additional_message) = format_comments(change, patchset) {
         format!("{}\n\n{}", message, additional_message)
     } else {
         message
@@ -1135,7 +1148,8 @@ mod test {
 {"author":{"name":"Approver","username":"approver"},"approvals":[{"type":"Code-Review","description":"Code-Review","value":"2","oldValue":"-1"}],"comment":"Patch Set 1: Code-Review+2\n\nJust a buggy script. FAILURE\n\nAnd more problems. FAILURE","patchSet":{"number":1,"revision":"49a65998c02eda928559f2d0b586c20bc8e37b10","parents":["fb1909b4eda306985d2bbce769310e5a50a98cf5"],"ref":"refs/changes/42/42/1","uploader":{"name":"Author","email":"author@example.com","username":"Author"},"createdOn":1494165142,"author":{"name":"Author","email":"author@example.com","username":"Author"},"isDraft":false,"kind":"REWORK","sizeInsertions":0,"sizeDeletions":0},"change":{"project":"demo-project","branch":"master","id":"Ic160fa37fca005fec17a2434aadf0d9dcfbb7b14","number":49,"subject":"Some review.","owner":{"name":"Author","email":"author@example.com","username":"author"},"url":"http://localhost/42","commitMessage":"Some review.\n\nChange-Id: Ic160fa37fca005fec17a2434aadf0d9dcfbb7b14\n","status":"NEW"},"project":"demo-project","refName":"refs/heads/master","changeKey":{"id":"Ic160fa37fca005fec17a2434aadf0d9dcfbb7b14"},"type":"comment-added","eventCreatedOn":1499190282}"#;
 
     const CHANGE_JSON_WITH_COMMENTS : &'static str = r#"
-{"project":"gerritbot-rs","branch":"master","id":"If70442f674c595a59f3e44280570e760ba3584c4","number":1,"subject":"Bump version to 0.6.0","owner":{"name":"Administrator","email":"admin@example.com","username":"admin"},"url":"http://localhost:8080/1","commitMessage":"Bump version to 0.6.0\n\nChange-Id: If70442f674c595a59f3e44280570e760ba3584c4\n","createdOn":1524584729,"lastUpdated":1524584975,"open":true,"status":"NEW","comments":[{"timestamp":1524584729,"reviewer":{"name":"Administrator","email":"admin@example.com","username":"admin"},"message":"Uploaded patch set 1."},{"timestamp":1524584975,"reviewer":{"name":"jdoe","email":"john.doe@localhost","username":"jdoe"},"message":"Patch Set 1:\n\n(1 comment)"}],"currentPatchSet":{"number":1,"revision":"3f58af760fc1e39fcc4a85b8ab6a6be032cf2ae2","parents":["578bc1e684098d2ac597e030442c3472f15ac3ad"],"ref":"refs/changes/01/1/1","uploader":{"name":"Administrator","email":"admin@example.com","username":"admin"},"createdOn":1524584729,"author":{"name":"jdoe","email":"jdoe@example.com","username":""},"isDraft":false,"kind":"REWORK","comments":[{"file":"/COMMIT_MSG","line":1,"reviewer":{"name":"jdoe","email":"john.doe@localhost","username":"jdoe"},"message":"This is a multiline\ncomment\non some change."}],"sizeInsertions":2,"sizeDeletions":-2}}"#;
+{"project":"gerritbot-rs","branch":"master","id":"If70442f674c595a59f3e44280570e760ba3584c4","number":1,"subject":"Bump version to 0.6.0","owner":{"name":"Administrator","email":"admin@example.com","username":"admin"},"url":"http://localhost:8080/1","commitMessage":"Bump version to 0.6.0\n\nChange-Id: If70442f674c595a59f3e44280570e760ba3584c4\n","createdOn":1524584729,"lastUpdated":1524584975,"open":true,"status":"NEW","comments":[{"timestamp":1524584729,"reviewer":{"name":"Administrator","email":"admin@example.com","username":"admin"},"message":"Uploaded patch set 1."},{"timestamp":1524584975,"reviewer":{"name":"jdoe","email":"john.doe@localhost","username":"jdoe"},"message":"Patch Set 1:\n\n(1 comment)"}]}"#;
+    const PATCHSET_JSON_WITH_COMMENTS : &'static str = r#"{"number":1,"revision":"3f58af760fc1e39fcc4a85b8ab6a6be032cf2ae2","parents":["578bc1e684098d2ac597e030442c3472f15ac3ad"],"ref":"refs/changes/01/1/1","uploader":{"name":"Administrator","email":"admin@example.com","username":"admin"},"createdOn":1524584729,"author":{"name":"jdoe","email":"jdoe@example.com","username":""},"isDraft":false,"kind":"REWORK","comments":[{"file":"/COMMIT_MSG","line":1,"reviewer":{"name":"jdoe","email":"john.doe@localhost","username":"jdoe"},"message":"This is a multiline\ncomment\non some change."}],"sizeInsertions":2,"sizeDeletions":-2}"#;
 
     fn get_event() -> gerrit::Event {
         let event: Result<gerrit::Event, _> = serde_json::from_str(EVENT_JSON);
@@ -1143,10 +1157,13 @@ mod test {
         event.unwrap()
     }
 
-    fn get_change_with_comments() -> gerrit::Change {
-        let event: Result<gerrit::Change, _> = serde_json::from_str(CHANGE_JSON_WITH_COMMENTS);
-        assert!(event.is_ok());
-        event.unwrap()
+    fn get_change_with_comments() -> (gerrit::Change, gerrit::PatchSet) {
+        let change: Result<gerrit::Change, _> = serde_json::from_str(CHANGE_JSON_WITH_COMMENTS);
+        assert!(change.is_ok());
+        let patchset: Result<gerrit::PatchSet, _> =
+            serde_json::from_str(PATCHSET_JSON_WITH_COMMENTS);
+        assert!(patchset.is_ok());
+        (change.unwrap(), patchset.unwrap())
     }
 
     #[test]
@@ -1660,23 +1677,23 @@ mod test {
     }
 
     #[test]
-    fn test_has_inline_comments() {
+    fn test_maybe_has_inline_comments() {
         let mut event = get_event();
         event.comment = Some("PatchSet 666: (2 comments)".into());
-        assert!(has_inline_comments(&event));
+        assert!(maybe_has_inline_comments(&event));
 
         event.comment = Some("Nope, colleague comment!".into());
-        assert!(!has_inline_comments(&event));
+        assert!(!maybe_has_inline_comments(&event));
     }
 
     #[test]
     fn test_format_comments() {
-        let mut event = get_change_with_comments();
-        event.current_patch_set = None;
-        assert_eq!(format_comments(event), None);
+        let (change, mut patchset) = get_change_with_comments();
+        patchset.comments = None;
+        assert_eq!(format_comments(change, patchset), None);
 
-        let event = get_change_with_comments();
-        assert_eq!(format_comments(event),
+        let (change, patchset) = get_change_with_comments();
+        assert_eq!(format_comments(change, patchset),
             Some("`/COMMIT_MSG`\n\n> [Line 1](https://localhost:8080/#/c/1/1//COMMIT_MSG@1) by jdoe: This is a multiline\n> comment\n> on some change.".into()));
     }
 }


### PR DESCRIPTION
There were multiple bugs.  Comments are now fetched on the patchset that
generated an event, not the current one but the formatting code wasn't
adapted.  Also, there was a logic error in the bot check.