### PR TITLE
remove default-members from root Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,3 @@ members = [
   "gerritbot-gerrit",
   "gerritbot-spark",
 ]
-default-members = ["gerritbot"]


### PR DESCRIPTION
It's not needed and makes it inconvenient to run just the tests for one of the
sub-crates.