### PR TITLE
make gerrit container non-persistent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,11 +10,13 @@ services:
       - ./.git:/root/src.git:ro
       - ./testing/data:/root/data
       - ./testing/prepopulate.nohup:/docker-entrypoint-init.d/prepopulate.nohup
+      - gerrit-site:/tmp/gerrit-site
     environment:
       - USER_NAME=gerrit
       - USER_EMAIL=gerrit@localhost
       - WEBURL=http://localhost:8080
       - AUTH_TYPE=DEVELOPMENT_BECOME_ANY_ACCOUNT
+      - GERRIT_SITE=/tmp/gerrit-site
 
   bot:
     build:
@@ -25,3 +27,10 @@ services:
       - ./testing/data/target:/src/target
     depends_on:
       - gerrit
+
+volumes:
+  gerrit-site:
+    driver_opts:
+      type: tmpfs
+      o: exec
+      device: tmpfs

--- a/testing/prepopulate.nohup
+++ b/testing/prepopulate.nohup
@@ -16,6 +16,8 @@ generate_ssh_key() {
     ssh-keygen -t rsa -f $ssh_key -q -N ""
   fi
 
+  rm -rf $HOME/.ssh/known_hosts
+
   echo -n "Uploading SSH public-key to Gerrit user ${1}: "
   curl -s --user admin:secret -X POST --url "http://localhost:8080/a/accounts/${1}/sshkeys" --data-binary "@${ssh_key}.pub"
 


### PR DESCRIPTION
By default the gerrit container uses a volume which means that changes,
reviews etc.  are persisted across restarts.  This is unhelpful for
testing.