### PR TITLE
make gerrit::Event into enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spectral 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ssh2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "stderrlog 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/gerritbot-gerrit/Cargo.toml
+++ b/gerritbot-gerrit/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1.0"
 ssh2 = "0.3"
 
 [dev-dependencies]
-structopt = "0.2"
+spectral = { version = "0.6", default-features = false }
 stderrlog = "0.4"
+structopt = "0.2"
 tokio = "0.1"


### PR DESCRIPTION
`gerrit::Event` is a `struct` with an `event_type` field and many fields being
modeled as `Option`. This is cumbersome and error prone because to use it one
would have to make assumptions or check the documentation about which fields are
being present when. In actuality the value of the `event_type` field determines
which fields should be present and this is well documented in Gerrit's
documentation. This change makes `gerrit::Event` into an `enum` with (currently) two
variants: `CommentAdded` and `ReviewerAdded`. Both are expressed as their own
`struct`s. This makes accessing common fields more difficult but improves the
logic in the bot and (hopefully) simplifies treating new event types in the
future.
