### PR TITLE
Update lua formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,11 +344,6 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "either"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,7 +460,6 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "gerritbot-gerrit 0.7.0",
  "gerritbot-spark 0.7.0",
- "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru_time_cache 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -635,14 +629,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "itertools"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1994,7 +1980,6 @@ dependencies = [
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
-"checksum either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c67353c641dc847124ea1902d69bd753dee9bb3beff9aa3662ecf86c971d1fac"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "07e791d3be96241c77c43846b665ef1384606da2cd2a48730abe606a12906e02"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
@@ -2021,7 +2006,6 @@ dependencies = [
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"

--- a/gerritbot-gerrit/src/lib.rs
+++ b/gerritbot-gerrit/src/lib.rs
@@ -9,19 +9,19 @@ use futures::sync::mpsc::{channel, Receiver, Sender};
 use futures::sync::oneshot;
 use futures::{future, Future, Sink, Stream};
 use log::{debug, error, info};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// Gerrit username
 pub type Username = String;
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct User {
     pub name: Option<String>,
     pub username: Option<Username>,
     pub email: String,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Approval {
     #[serde(rename = "type")]
@@ -31,7 +31,7 @@ pub struct Approval {
     pub old_value: Option<String>,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Patchset {
     pub number: u32,
@@ -49,7 +49,7 @@ pub struct Patchset {
     pub comments: Option<Vec<InlineComment>>,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct InlineComment {
     pub file: String,
@@ -58,7 +58,7 @@ pub struct InlineComment {
     pub message: String,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub enum ChangeStatus {
     NEW,
     DRAFT,
@@ -67,20 +67,20 @@ pub enum ChangeStatus {
 }
 
 #[allow(non_camel_case_types)]
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub enum SubmitStatus {
     OK,
     NOT_READY,
     RULE_ERROR,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SubmitRecord {
     status: SubmitStatus,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Change {
     pub project: String,
@@ -99,20 +99,20 @@ pub struct Change {
     pub submit_records: Option<Vec<SubmitRecord>>,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct Comment {
     pub timestamp: u64,
     pub reviewer: User,
     pub message: String,
 }
 
-#[derive(Deserialize, Debug, Eq, PartialEq, Hash, Clone)]
+#[derive(Deserialize, Serialize, Debug, Eq, PartialEq, Hash, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ChangeKey {
     pub id: String,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct CommentAddedEvent {
     pub change: Change,
     #[serde(rename = "patchSet")]
@@ -124,7 +124,7 @@ pub struct CommentAddedEvent {
     pub created_on: u32,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ReviewerAddedEvent {
     pub change: Change,
     #[serde(rename = "patchSet")]
@@ -134,7 +134,7 @@ pub struct ReviewerAddedEvent {
     pub created_on: u32,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 #[serde(tag = "type")]
 pub enum Event {
     #[serde(rename = "comment-added")]

--- a/gerritbot-spark/src/lib.rs
+++ b/gerritbot-spark/src/lib.rs
@@ -337,14 +337,6 @@ impl From<hyper::Error> for Error {
     }
 }
 
-/*
-impl From<sqs::Error> for Error {
-    fn from(err: sqs::Error) -> Self {
-        Error::SqsError(err)
-    }
-}
-*/
-
 impl From<serde_json::Error> for Error {
     fn from(err: serde_json::Error) -> Self {
         Error::JsonError(err)

--- a/gerritbot/Cargo.toml
+++ b/gerritbot/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 futures = "0.1"
 gerritbot-gerrit = { path = "../gerritbot-gerrit" }
 gerritbot-spark = { path = "../gerritbot-spark" }
-itertools = "0.8"
 lazy_static = "1.3"
 log = "0.4"
 lru_time_cache = "0.9"

--- a/gerritbot/examples/gerritbot-console.rs
+++ b/gerritbot/examples/gerritbot-console.rs
@@ -176,18 +176,6 @@ fn main() {
     );
     let gerrit_command_runner = gerrit::CommandRunner::new(connect_to_gerrit());
     let bot_builder = bot::Builder::new(bot::State::new());
-    let bot_builder = {
-        if let Some(format_script) = args.format_script {
-            bot_builder
-                .with_format_script(format_script)
-                .unwrap_or_else(|err| {
-                    error!("Failed to set format script: {:?}", err);
-                    std::process::exit(1);
-                })
-        } else {
-            bot_builder
-        }
-    };
     let (stdin_lines_sender, stdin_lines) = channel(1);
     std::thread::spawn(move || {
         stream::iter_ok::<_, ()>(

--- a/gerritbot/examples/gerritbot-console.rs
+++ b/gerritbot/examples/gerritbot-console.rs
@@ -176,6 +176,18 @@ fn main() {
     );
     let gerrit_command_runner = gerrit::CommandRunner::new(connect_to_gerrit());
     let bot_builder = bot::Builder::new(bot::State::new());
+    let bot_builder = {
+        if let Some(format_script) = args.format_script {
+            bot_builder
+                .with_format_script(&format_script)
+                .unwrap_or_else(|err| {
+                    error!("Failed to set format script: {:?}", err);
+                    std::process::exit(1);
+                })
+        } else {
+            bot_builder
+        }
+    };
     let (stdin_lines_sender, stdin_lines) = channel(1);
     std::thread::spawn(move || {
         stream::iter_ok::<_, ()>(

--- a/gerritbot/src/args.rs
+++ b/gerritbot/src/args.rs
@@ -38,6 +38,7 @@ pub enum ModeConfig {
 pub struct BotConfig {
     pub msg_expiration: u64,
     pub msg_capacity: usize,
+    pub format_script: Option<String>,
 }
 
 /// Cisco Webex Teams <> Gerrit Bot

--- a/gerritbot/src/args.rs
+++ b/gerritbot/src/args.rs
@@ -43,6 +43,7 @@ pub struct BotConfig {
 
 /// Cisco Webex Teams <> Gerrit Bot
 #[derive(StructOpt, Debug, Clone)]
+#[structopt(rename_all = "kebab-case")]
 pub struct Args {
     /// Print more
     #[structopt(short, long)]
@@ -53,6 +54,9 @@ pub struct Args {
     /// YAML configuration file
     #[structopt(long, short, default_value = "config.yml")]
     pub config: PathBuf,
+    /// Dump default format script and exit
+    #[structopt(long)]
+    pub dump_format_script: bool,
 }
 
 pub fn parse_args() -> Args {

--- a/gerritbot/src/args.rs
+++ b/gerritbot/src/args.rs
@@ -38,7 +38,6 @@ pub enum ModeConfig {
 pub struct BotConfig {
     pub msg_expiration: u64,
     pub msg_capacity: usize,
-    pub format_script: Option<String>,
 }
 
 /// Cisco Webex Teams <> Gerrit Bot

--- a/gerritbot/src/bin/gerritbot.rs
+++ b/gerritbot/src/bin/gerritbot.rs
@@ -85,18 +85,6 @@ fn main() {
             bot_builder
         }
     };
-    let bot_builder = {
-        if let Some(format_script) = bot_config.format_script {
-            bot_builder
-                .with_format_script(format_script)
-                .unwrap_or_else(|err| {
-                    error!("Failed to set format script: {:?}", err);
-                    std::process::exit(1);
-                })
-        } else {
-            bot_builder
-        }
-    };
     let connect_to_gerrit = || {
         info!(
             "Connecting to gerrit with username {} at {}",

--- a/gerritbot/src/bin/gerritbot.rs
+++ b/gerritbot/src/bin/gerritbot.rs
@@ -7,10 +7,10 @@ use std::time::Duration;
 use futures::{future, future::lazy, Future, Stream};
 use log::{debug, error, info, warn};
 
+use gerritbot as bot;
+use gerritbot::args;
 use gerritbot_gerrit as gerrit;
 use gerritbot_spark as spark;
-use gerritbot as bot;
-use gerritbot::args as args;
 
 /// Create spark message stream. Returns a future representing a webhook server
 /// and a stream of messages.
@@ -41,6 +41,12 @@ fn create_spark_message_stream(
 
 fn main() {
     let args = args::parse_args();
+
+    if args.dump_format_script {
+        print!("{}", bot::DEFAULT_FORMAT_SCRIPT);
+        return;
+    }
+
     stderrlog::new()
         .module(module_path!())
         .module("gerritbot_gerrit")

--- a/gerritbot/src/bin/gerritbot.rs
+++ b/gerritbot/src/bin/gerritbot.rs
@@ -85,6 +85,18 @@ fn main() {
             bot_builder
         }
     };
+    let bot_builder = {
+        if let Some(format_script) = bot_config.format_script {
+            bot_builder
+                .with_format_script(&format_script)
+                .unwrap_or_else(|err| {
+                    error!("Failed to set format script: {:?}", err);
+                    std::process::exit(1);
+                })
+        } else {
+            bot_builder
+        }
+    };
     let connect_to_gerrit = || {
         info!(
             "Connecting to gerrit with username {} at {}",

--- a/gerritbot/src/format.rs
+++ b/gerritbot/src/format.rs
@@ -98,6 +98,12 @@ fn to_lua_via_json<'lua, T: Serialize>(
 }
 
 impl Formatter {
+    pub fn new(format_script: &str) -> Result<Self, String> {
+        Ok(Self {
+            lua: load_format_script(&format_script)?,
+        })
+    }
+
     fn format_lua<'lua, T, E, F, A>(
         lua: rlua::Context<'lua>,
         function_name: &str,

--- a/gerritbot/src/format.rs
+++ b/gerritbot/src/format.rs
@@ -203,7 +203,7 @@ mod test {
         let res = res.as_ref().map(|o| o.as_ref().map(String::as_str));
         assert_eq!(
             res,
-            Ok(Some("[Some review.](http://localhost/42) ([demo-project](http://localhost/q/project:demo-project+status:open)) 👍 +2 (Some-New-Type) from [Approver](http://localhost/q/reviewer:approver@approvers.com+status:open)\n\n> Just a buggy script. FAILURE\n\n> And more problems. FAILURE"))
+            Ok(Some("[Some review.](http://localhost/42) ([demo-project](http://localhost/q/project:demo-project+status:open)) 🤩 +2 (Some-New-Type) from [Approver](http://localhost/q/reviewer:approver@approvers.com+status:open)\n\n> Just a buggy script. FAILURE\n\n> And more problems. FAILURE"))
         );
     }
 
@@ -221,7 +221,7 @@ mod test {
         let res = res.as_ref().map(|o| o.as_ref().map(String::as_str));
         assert_eq!(
             res,
-            Ok(Some("[Some review.](http://localhost/42) ([demo-project](http://localhost/q/project:demo-project+status:open)) 👍 +2 (Code-Review), ✔ +1 (Verified) from [Approver](http://localhost/q/reviewer:approver@approvers.com+status:open)\n\n> Just a buggy script. FAILURE\n\n> And more problems. FAILURE"))
+            Ok(Some("[Some review.](http://localhost/42) ([demo-project](http://localhost/q/project:demo-project+status:open)) 👍 +2 (Code-Review), 🌞 +1 (Verified) from [Approver](http://localhost/q/reviewer:approver@approvers.com+status:open)\n\n> Just a buggy script. FAILURE\n\n> And more problems. FAILURE"))
         );
     }
 

--- a/gerritbot/src/format.rs
+++ b/gerritbot/src/format.rs
@@ -1,6 +1,6 @@
 use itertools::Itertools as _;
 
-use rlua::{FromLua as _, Function as LuaFunction, Lua, Value as LuaValue};
+use rlua::{FromLua as _, Function as LuaFunction, Lua, StdLib as LuaStdLib, Value as LuaValue};
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 
@@ -22,7 +22,8 @@ impl Default for Formatter {
 }
 
 fn load_format_script(script_source: &str) -> Result<Lua, String> {
-    let lua = Lua::new();
+    let lua_std_lib = LuaStdLib::BASE | LuaStdLib::STRING | LuaStdLib::TABLE;
+    let lua = Lua::new_with(lua_std_lib);
     lua.context(|context| -> Result<(), String> {
         let globals = context.globals();
         context

--- a/gerritbot/src/format.rs
+++ b/gerritbot/src/format.rs
@@ -178,7 +178,7 @@ mod test {
         let res = res.as_ref().map(|o| o.as_ref().map(String::as_str));
         assert_eq!(
             res,
-            Ok(Some("[Some review.](http://localhost/42) ([demo-project](http://localhost/q/project:demo-project+status:open)) 👍 +2 (Code-Review) from [Approver](http://localhost/q/reviewer:approver@approvers.com+status:open)\n\n> Just a buggy script. FAILURE<br>\n> And more problems. FAILURE"))
+            Ok(Some("[Some review.](http://localhost/42) ([demo-project](http://localhost/q/project:demo-project+status:open)) 👍 +2 (Code-Review) from [Approver](http://localhost/q/reviewer:approver@approvers.com+status:open)\n\n> Just a buggy script. FAILURE\n\n> And more problems. FAILURE"))
         );
     }
 
@@ -191,7 +191,7 @@ mod test {
         let res = res.as_ref().map(|o| o.as_ref().map(String::as_str));
         assert_eq!(
             res,
-            Ok(Some("[Some review.](http://localhost/42) ([demo-project](http://localhost/q/project:demo-project+status:open)) 👍 +2 (Some-New-Type) from [Approver](http://localhost/q/reviewer:approver@approvers.com+status:open)\n\n> Just a buggy script. FAILURE<br>\n> And more problems. FAILURE"))
+            Ok(Some("[Some review.](http://localhost/42) ([demo-project](http://localhost/q/project:demo-project+status:open)) 👍 +2 (Some-New-Type) from [Approver](http://localhost/q/reviewer:approver@approvers.com+status:open)\n\n> Just a buggy script. FAILURE\n\n> And more problems. FAILURE"))
         );
     }
 
@@ -209,7 +209,7 @@ mod test {
         let res = res.as_ref().map(|o| o.as_ref().map(String::as_str));
         assert_eq!(
             res,
-            Ok(Some("[Some review.](http://localhost/42) ([demo-project](http://localhost/q/project:demo-project+status:open)) 👍 +2 (Code-Review), ✔ +1 (Verified) from [Approver](http://localhost/q/reviewer:approver@approvers.com+status:open)\n\n> Just a buggy script. FAILURE<br>\n> And more problems. FAILURE"))
+            Ok(Some("[Some review.](http://localhost/42) ([demo-project](http://localhost/q/project:demo-project+status:open)) 👍 +2 (Code-Review), ✔ +1 (Verified) from [Approver](http://localhost/q/reviewer:approver@approvers.com+status:open)\n\n> Just a buggy script. FAILURE\n\n> And more problems. FAILURE"))
         );
     }
 

--- a/gerritbot/src/format.rs
+++ b/gerritbot/src/format.rs
@@ -99,27 +99,25 @@ impl Formatter {
         event: &gerrit::CommentAddedEvent,
         is_human: bool,
     ) -> Result<Option<String>, String> {
-        self.lua
-            .context(|context| -> Result<Option<String>, String> {
-                let globals = context.globals();
+        self.lua.context(|context| {
+            let globals = context.globals();
 
-                let lua_format_comment_added: LuaFunction =
-                    globals
-                        .get(LUA_FORMAT_COMMENT_ADDED)
-                        .map_err(|_| "format_approval function missing".to_string())?;
-                let lua_event = to_lua_via_json(event, context)
-                    .map_err(|e| format!("failed to serialize event: {}", e))?;
-                let lua_result = lua_format_comment_added
-                    .call::<_, LuaValue>((lua_event, is_human))
-                    .map_err(|err| format!("lua formatting function failed: {}", err))?;
+            let lua_format_comment_added: LuaFunction = globals
+                .get(LUA_FORMAT_COMMENT_ADDED)
+                .map_err(|_| "format_approval function missing".to_string())?;
+            let lua_event = to_lua_via_json(event, context)
+                .map_err(|e| format!("failed to serialize event: {}", e))?;
+            let lua_result = lua_format_comment_added
+                .call::<_, LuaValue>((lua_event, is_human))
+                .map_err(|err| format!("lua formatting function failed: {}", err))?;
 
-                match lua_result {
-                    LuaValue::Nil => Ok(None),
-                    _ => Ok(Some(String::from_lua(lua_result, context).map_err(
-                        |e| format!("failed to convert formatting result to string: {}", e),
-                    )?)),
-                }
-            })
+            match lua_result {
+                LuaValue::Nil => Ok(None),
+                _ => Ok(Some(String::from_lua(lua_result, context).map_err(
+                    |e| format!("failed to convert formatting result to string: {}", e),
+                )?)),
+            }
+        })
     }
 
     pub fn format_reviewer_added(

--- a/gerritbot/src/format.rs
+++ b/gerritbot/src/format.rs
@@ -269,9 +269,11 @@ mod test {
     fn test_format_approval() {
         let event = get_event();
         let res = Formatter::default().format_approval(&event, &event.approvals[0], true);
+        // Result<Option<String>, _> -> Result<Option<&str>, _>
+        let res = res.as_ref().map(|o| o.as_ref().map(String::as_str));
         assert_eq!(
             res,
-            Ok(Some("[Some review.](http://localhost/42) (demo-project) 👍 +2 (Code-Review) from approver\n\n> Just a buggy script. FAILURE<br>\n> And more problems. FAILURE".to_string()))
+            Ok(Some("[Some review.](http://localhost/42) ([demo-project](http://localhost/q/project:demo-project+status:open)) 👍 +2 (Code-Review) from [Approver](http://localhost/q/reviewer:approver@approvers.com+status:open)\n\n> Just a buggy script. FAILURE<br>\n> And more problems. FAILURE"))
         );
     }
 

--- a/gerritbot/src/format.rs
+++ b/gerritbot/src/format.rs
@@ -236,6 +236,6 @@ mod test {
             .expect("format failed")
             .expect("no comments");
 
-        assert!(res.ends_with("`/COMMIT_MSG`\n\n> [Line 1](http://localhost:8080/#/c/1/1//COMMIT_MSG@1) by jdoe: This is a multiline\n> comment\n> on some change.\n"), "no inline comments: {:?}", res);
+        assert!(res.ends_with("`/COMMIT_MSG`\n\n> [Line 1](http://localhost:8080/#/c/1/1//COMMIT_MSG@1) by [jdoe](http://localhost:8080/q/reviewer:john.doe@localhost+status:open): This is a multiline\n> comment\n> on some change.\n"), "no inline comments: {:?}", res);
     }
 }

--- a/gerritbot/src/format.rs
+++ b/gerritbot/src/format.rs
@@ -40,11 +40,6 @@ fn check_format_script_syntax(script_source: &str) -> Result<(), String> {
 }
 
 impl Formatter {
-    pub fn new(format_script: String) -> Result<Self, String> {
-        check_format_script_syntax(&format_script)?;
-        Ok(Self { format_script })
-    }
-
     pub fn format_approval(
         &self,
         event: &gerrit::CommentAddedEvent,

--- a/gerritbot/src/format.rs
+++ b/gerritbot/src/format.rs
@@ -8,7 +8,7 @@ use serde_json::Value as JsonValue;
 
 use gerritbot_gerrit as gerrit;
 
-const DEFAULT_FORMAT_SCRIPT: &str = include_str!("../../scripts/format.lua");
+pub const DEFAULT_FORMAT_SCRIPT: &str = include_str!("../../scripts/format.lua");
 const LUA_FORMAT_COMMENT_ADDED: &str = "format_comment_added";
 const LUA_FORMAT_REVIEWER_ADDED: &str = "format_reviewer_added";
 const LUA_FORMAT_FUNCTIONS: &[&str] = &[LUA_FORMAT_COMMENT_ADDED, LUA_FORMAT_REVIEWER_ADDED];

--- a/gerritbot/src/lib.rs
+++ b/gerritbot/src/lib.rs
@@ -96,7 +96,7 @@ struct MsgCacheParameters {
     expiration: Duration,
 }
 
-#[derive(Default, Clone)]
+#[derive(Default)]
 pub struct Builder {
     state: State,
     rate_limiter: RateLimiter,

--- a/gerritbot/src/lib.rs
+++ b/gerritbot/src/lib.rs
@@ -321,6 +321,13 @@ impl Builder {
         }
     }
 
+    pub fn with_format_script(self, script_source: &str) -> Result<Self, String> {
+        Ok(Self {
+            formatter: Formatter::new(script_source)?,
+            ..self
+        })
+    }
+
     pub fn build<G, S>(self, gerrit_command_runner: G, spark_client: S) -> Bot<G, S> {
         let Self {
             formatter,

--- a/gerritbot/src/lib.rs
+++ b/gerritbot/src/lib.rs
@@ -20,6 +20,7 @@ mod format;
 mod rate_limit;
 
 use format::Formatter;
+pub use format::DEFAULT_FORMAT_SCRIPT;
 use rate_limit::RateLimiter;
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/gerritbot/src/lib.rs
+++ b/gerritbot/src/lib.rs
@@ -321,13 +321,6 @@ impl Builder {
         }
     }
 
-    pub fn with_format_script(self, script_source: String) -> Result<Self, String> {
-        Ok(Self {
-            formatter: Formatter::new(script_source)?,
-            ..self
-        })
-    }
-
     pub fn build<G, S>(self, gerrit_command_runner: G, spark_client: S) -> Bot<G, S> {
         let Self {
             formatter,

--- a/scripts/format.lua
+++ b/scripts/format.lua
@@ -1,3 +1,63 @@
+-- Get the Gerrit base URL from the given change URL.
+function get_gerrit_base_url(change_url)
+    return string.sub(change_url, 1, #change_url - string.find(string.reverse(change_url), "/"))
+end
+
+-- Get a URL for a Gerrit query.
+function get_query_url(base_url, query, ...)
+    return string.format("%s/q/%s", base_url, string.format(query, ...))
+end
+
+-- Format a link.
+function format_link(text, target)
+    return string.format("[%s](%s)", text, target)
+end
+
+-- Format a link to a Gerrit query.
+function format_query_link(base_url, text, query, ...)
+    return format_link(text, get_query_url(base_url, query, ...))
+end
+
+-- Format a link to a user.
+function format_user(base_url, user, role)
+    return format_query_link(
+        base_url,
+        user.name or user.email,
+        "%s:%s+status:open",
+        role, user.email
+    )
+end
+
+-- Format a change's subject.
+function format_change_subject(change)
+    return format_link(change.subject, change.url)
+end
+
+-- Format a change's project.
+function format_change_project(base_url, change)
+    local result = format_query_link(
+        base_url,
+        change.project,
+        "project:%s+status:open",
+        change.project
+    )
+
+    if change.branch ~= "master" then
+        result = result .. ", branch:" .. change.branch
+    end
+
+    if change.topic then
+        result = result .. ", topic:" .. format_query_link(
+            base_url,
+            change.topic,
+            "topic:%s+status:open",
+            change.topic
+        )
+    end
+
+    return result
+end
+
 -- Filter and format messages
 -- return nil to filter the message
 function format_approval(event, approval, is_human)
@@ -5,7 +65,12 @@ function format_approval(event, approval, is_human)
         return
     end
 
-    approval_value = tonumber(approval.value)
+    local change = event.change
+    local base_url = get_gerrit_base_url(change.url)
+
+    local msg = format_change_subject(change) .. " (" .. format_change_project(base_url, change) .. ")"
+
+    local approval_value = tonumber(approval.value)
 
     if string.match(approval.type, "WaitForVerification") then
         icon = "⌛"
@@ -17,18 +82,16 @@ function format_approval(event, approval, is_human)
         icon = "👎"
     end
 
-    sign = ""
+    local sign = ""
     if approval_value > 0 then
         sign = "+"
     end
 
-    -- TODO: when Spark will allow to format text with different colors, set
-    -- green resp. red color here.
-    f = "[%s](%s) (%s) %s %s%s (%s) from %s"
-    msg = string.format(f, event.change.subject, event.change.url, event.change.project, icon, sign, approval_value, approval.type, event.author.username)
+    msg = msg .. string.format(" %s %s%s (%s)", icon, sign, approval_value, approval.type)
+    msg = msg .. " from " .. format_user(base_url, event.author, "reviewer")
 
-    len = 0
-    lines = {}
+    local len = 0
+    local lines = {}
     for line in string.gmatch(event.comment, "[^\r\n]+") do
         if is_human and not line:match "^Patch Set" and not line:match "%(%d+ comments?%)" then
             table.insert(lines, "> " .. line)

--- a/scripts/format.lua
+++ b/scripts/format.lua
@@ -212,10 +212,12 @@ end
 
 function format_reviewer_added(event)
     local change = event.change
+    local base_url = get_gerrit_base_url(change.url)
 
     return string.format(
-        "%s (%s) 👓 Added as reviewer",
+        "%s (%s) by %s 👓 Added as reviewer",
         format_change_subject(change),
-        (change.owner.username or "<unknown user>")
+        format_change_project(base_url, change),
+        format_user(base_url, change.owner, "owner")
     )
 end

--- a/scripts/format.lua
+++ b/scripts/format.lua
@@ -211,6 +211,14 @@ function format_comment_added(event, is_human)
     end
 
     msg = msg .. " from " .. format_user(base_url, event.author, "reviewer")
+
+    for _i, submit_record in ipairs(change.submitRecords or {}) do
+        if submit_record.status == "OK" then
+            msg = msg .. ", 🏁 Submittable"
+            break
+        end
+    end
+
     msg = msg .. (format_comment(event.comment, is_human) or "")
     msg = msg .. (format_inline_comments(base_url, change, patchset) or "")
 

--- a/scripts/format.lua
+++ b/scripts/format.lua
@@ -81,8 +81,13 @@ local function get_approval_icon(type, value, old_value)
 end
 
 local function format_approval(approval)
-    local approval_value = tonumber(approval.value)
-    local old_approval_value = tonumber(approval.old_value or "0")
+    local approval_value = tonumber(approval.value) or 0
+    local old_approval_value = tonumber(approval.oldValue) or 0
+
+    if old_approval_value == approval_value then
+        return nil
+    end
+
     local icon = get_approval_icon(approval.type, approval_value, old_approval_value)
 
     local sign = ""
@@ -185,6 +190,8 @@ function format_comment_added(event, is_human)
     local msg = format_change_subject(change) .. " (" .. format_change_project(base_url, change) .. ")"
 
     local formatted_approvals = {}
+
+    table.sort(event.approvals, function(a1, a2) return a1.type < a2.type end)
 
     for _i, approval in ipairs(event.approvals) do
         local formatted_approval = format_approval(approval)

--- a/scripts/format.lua
+++ b/scripts/format.lua
@@ -209,3 +209,13 @@ function format_comment_added(event, is_human)
 
     return msg
 end
+
+function format_reviewer_added(event)
+    local change = event.change
+
+    return string.format(
+        "%s (%s) 👓 Added as reviewer",
+        format_change_subject(change),
+        (change.owner.username or "<unknown user>")
+    )
+end

--- a/scripts/format.lua
+++ b/scripts/format.lua
@@ -58,12 +58,14 @@ local function format_change_project(base_url, change)
     return result
 end
 
+-- Lua string pattern → table of emoji
 local APPROVAL_ICONS = {
-    ["WaitForVerification"] = {[-1] = "⏳"},
-    ["Code-Review"] = {[-2] = "👎", [-1] = "🤷", [1] = "👌", [2] = "👍"},
-    ["Verified"] = {[-1] = "❌", [1] = "✔"},
+    {"WaitForVerification", {[-1] = "⏳"}},
+    {"Code[-]Review", {[-2] = "👎", [-1] = "✋", [1] = "👌", [2] = "👍"}},
+    {"Verified", {[-1] = "⛈️", [1] = "🌞"}},
+    {"QA", {[-1] = "❌", [1] = "✅"}},
     -- fallback
-    ["*"] = {[-2] = "👎", [-1] = "🙅", [1] = "🙆", [2] = "👍"},
+    {"", {[-2] = "😬", [-1] = "🤨", [1] = "😉", [2] = "🤩"}},
 }
 
 local function get_approval_icon(type, value, old_value)
@@ -75,9 +77,14 @@ local function get_approval_icon(type, value, old_value)
         end
     end
 
-    type_icons = APPROVAL_ICONS[type] or APPROVAL_ICONS["*"]
+    for _, item in pairs(APPROVAL_ICONS) do
+        local type_pattern = item[1]
+        local type_icons = item[2]
 
-    return type_icons[value]
+        if string.match(string.lower(type), string.lower(type_pattern)) then
+            return type_icons[value]
+        end
+    end
 end
 
 local function format_approval(approval)

--- a/scripts/format.lua
+++ b/scripts/format.lua
@@ -99,10 +99,89 @@ local function format_approval(approval)
     return string.format("%s%s%s (%s)", icon, sign, approval_value, approval.type)
 end
 
+-- return an iterator over the lines in the given string
+local function lines_iter(s)
+    return string.gmatch(s, "[^\r\n]+")
+end
+
+local function format_comment(comment, is_human)
+    local lines = {}
+
+    for line in lines_iter(comment) do
+        if is_human and not line:match "^Patch Set" and not line:match "%(%d+ comments?%)" then
+            table.insert(lines, "> " .. line)
+        elseif string.match(line, "FAILURE") then
+            table.insert(lines, "> " .. line)
+        end
+    end
+
+    if #lines > 0 then
+        -- XXX: change <br> to \n
+        return "\n\n" .. table.concat(lines, "<br>\n")
+    end
+end
+
+local function format_inline_comment(base_url, change, patchset, comment)
+    local lines = {}
+
+    for line in lines_iter(comment.message) do
+        if #lines == 0 then
+            local url = string.format(
+                "%s/#/c/%s/%s/%s@%s",
+                base_url,
+                change.number,
+                patchset.number,
+                comment.file,
+                comment.line
+            )
+
+            table.insert(
+                lines,
+                string.format(
+                    "> [Line %s](%s) by %s: %s",
+                    comment.line,
+                    url,
+                    -- TODO: use format_user
+                    comment.reviewer.username,
+                    line
+                )
+            )
+
+        else
+            table.insert(lines, "> " .. line)
+        end
+    end
+
+    return table.concat(lines, "\n")
+end
+
+local function format_inline_comments(base_url, change, patchset)
+    local lines = {}
+    local comments = patchset.comments or {}
+
+    table.sort(comments, function (c1, c2) return c1.file < c2.file end)
+
+    local file
+
+    for _i, comment in ipairs(comments) do
+        if comment.file ~= file then
+            file = comment.file
+            table.insert(lines, string.format("`%s`", file))
+        end
+
+        table.insert(lines, format_inline_comment(base_url, change, patchset, comment))
+    end
+
+    if #lines > 0 then
+        return "\n\n" .. table.concat(lines, "\n\n") .. "\n"
+    end
+end
+
 -- Filter and format messages
 -- return nil to filter the message
 function format_comment_added(event, is_human)
     local change = event.change
+    local patchset = event.patchSet
     local base_url = get_gerrit_base_url(change.url)
 
     local msg = format_change_subject(change) .. " (" .. format_change_project(base_url, change) .. ")"
@@ -119,7 +198,7 @@ function format_comment_added(event, is_human)
 
     if #formatted_approvals > 0 then
         msg = msg .. " " .. table.concat(formatted_approvals, ", ")
-    else
+    elseif not (is_human and patchset.comments and #patchset.comments > 0) then
         -- TODO: messages without approvals should still be formatted since they
         -- can be comment responses. This should be handled at a higher level.
         -- Keep this here for now to prevent spamming.
@@ -127,23 +206,8 @@ function format_comment_added(event, is_human)
     end
 
     msg = msg .. " from " .. format_user(base_url, event.author, "reviewer")
+    msg = msg .. (format_comment(event.comment, is_human) or "")
+    msg = msg .. (format_inline_comments(base_url, change, patchset) or "")
 
-    local len = 0
-    local lines = {}
-    for line in string.gmatch(event.comment, "[^\r\n]+") do
-        if is_human and not line:match "^Patch Set" and not line:match "%(%d+ comments?%)" then
-            table.insert(lines, "> " .. line)
-            len = len + 1
-        elseif string.match(line, "FAILURE") then
-            table.insert(lines, "> " .. line)
-            len = len + 1
-        end
-    end
-
-    if len == 0 then
-        return msg
-    else
-        lines = table.concat(lines, "<br>\n")
-        return msg .. "\n\n" .. lines
-    end
+    return msg
 end

--- a/scripts/format.lua
+++ b/scripts/format.lua
@@ -116,8 +116,7 @@ local function format_comment(comment, is_human)
     end
 
     if #lines > 0 then
-        -- XXX: change <br> to \n
-        return "\n\n" .. table.concat(lines, "<br>\n")
+        return "\n\n" .. table.concat(lines, "\n\n")
     end
 end
 

--- a/scripts/format.lua
+++ b/scripts/format.lua
@@ -1,25 +1,25 @@
 -- Get the Gerrit base URL from the given change URL.
-function get_gerrit_base_url(change_url)
+local function get_gerrit_base_url(change_url)
     return string.sub(change_url, 1, #change_url - string.find(string.reverse(change_url), "/"))
 end
 
 -- Get a URL for a Gerrit query.
-function get_query_url(base_url, query, ...)
+local function get_query_url(base_url, query, ...)
     return string.format("%s/q/%s", base_url, string.format(query, ...))
 end
 
 -- Format a link.
-function format_link(text, target)
+local function format_link(text, target)
     return string.format("[%s](%s)", text, target)
 end
 
 -- Format a link to a Gerrit query.
-function format_query_link(base_url, text, query, ...)
+local function format_query_link(base_url, text, query, ...)
     return format_link(text, get_query_url(base_url, query, ...))
 end
 
 -- Format a link to a user.
-function format_user(base_url, user, role)
+local function format_user(base_url, user, role)
     return format_query_link(
         base_url,
         user.name or user.email,
@@ -29,12 +29,12 @@ function format_user(base_url, user, role)
 end
 
 -- Format a change's subject.
-function format_change_subject(change)
+local function format_change_subject(change)
     return format_link(change.subject, change.url)
 end
 
 -- Format a change's project.
-function format_change_project(base_url, change)
+local function format_change_project(base_url, change)
     local result = format_query_link(
         base_url,
         change.project,

--- a/scripts/format.lua
+++ b/scripts/format.lua
@@ -141,8 +141,7 @@ local function format_inline_comment(base_url, change, patchset, comment)
                     "> [Line %s](%s) by %s: %s",
                     comment.line,
                     url,
-                    -- TODO: use format_user
-                    comment.reviewer.username,
+                    format_user(base_url, comment.reviewer, "reviewer"),
                     line
                 )
             )

--- a/tests/features/comments.feature
+++ b/tests/features/comments.feature
@@ -14,6 +14,7 @@ Feature: review comments
       When we check for messages by the bot
       Then there is a message for Bob which includes the text "Code-Review"
        And this message includes the text "+2"
+       And this message includes the text "Submittable"
 
   Scenario: review with message
      Given Bob uploads a new change to the tools project
@@ -22,6 +23,23 @@ Feature: review comments
       Then there is a message for Bob which includes the text "Code-Review"
        And this message includes the text "+2"
        And this message includes the text "Good job!"
+       And this message includes the text "Submittable"
+
+  Scenario: insufficient review without message
+     Given Bob uploads a new change to the tools project
+       And Alice replies to Bob's change with Code-Review+1
+      When we check for messages by the bot
+      Then there is a message for Bob which includes the text "Code-Review"
+       And this message includes the text "+1"
+       And this message does not include the text "Submittable"
+
+  Scenario: insufficient review without message
+     Given Bob uploads a new change to the tools project
+       And Alice replies to Bob's change with Code-Review+1 and the comment "Okay job."
+      When we check for messages by the bot
+      Then there is a message for Bob which includes the text "Code-Review"
+       And this message includes the text "+1"
+       And this message does not include the text "Submittable"
 
   Scenario: inline comments
      Given Bob uploads a new change to the tools project

--- a/tests/features/environment.py
+++ b/tests/features/environment.py
@@ -5,6 +5,7 @@ from behave import use_fixture
 from gerritbot_behave.gerrit import setup_gerrit
 from gerritbot_behave.bot import setup_bot
 from gerritbot_behave.persons import Persons, Person
+from gerritbot_behave.format import URLs
 
 
 def before_all(context):
@@ -38,6 +39,7 @@ def before_all(context):
     context.bot_user = Person("gerritbot", "gerritbot@gerritbot.rs")
     context.gerrit.create_user(context.bot_user)
     context.gerrit.add_user_to_group(context.bot_user, "Non-Interactive+Users")
+    context.urls = URLs(context)
 
 
 def before_scenario(context, scenario):

--- a/tests/features/formatting.feature
+++ b/tests/features/formatting.feature
@@ -14,7 +14,7 @@ Feature: message formatting
       When we check for messages by the bot
       Then there is a message for Bob with the following text:
         """
-        [{context.last_created_change[subject]}]({context.gerrit.http_url}/{context.last_created_change[_number]}) (tools) 👍 +2 (Code-Review) from alice
+        [{context.last_created_change[subject]}]({context.urls.changes[last]}) ([tools]({context.urls.projects[tools]})) 👍 +2 (Code-Review) from [Alice Smith]({context.urls.users[alice].reviewer})
         """
 
   Scenario: review with message
@@ -23,7 +23,7 @@ Feature: message formatting
       When we check for messages by the bot
       Then there is a message for Bob with the following text:
         """
-        [{context.last_created_change[subject]}]({context.gerrit.http_url}/{context.last_created_change[_number]}) (tools) 👍 +2 (Code-Review) from alice
+        [{context.last_created_change[subject]}]({context.urls.changes[last]}) ([tools]({context.urls.projects[tools]})) 👍 +2 (Code-Review) from [Alice Smith]({context.urls.users[alice].reviewer})
 
         > Good job!
         """
@@ -60,7 +60,7 @@ Feature: message formatting
       When we check for messages by the bot
       Then there is a message for Bob with the following text:
         """
-        [{context.last_created_change[subject]}]({context.gerrit.http_url}/{context.last_created_change[_number]}) (tools) 👎 -2 (Code-Review) from alice
+        [{context.last_created_change[subject]}]({context.urls.changes[last]}) ([tools]({context.urls.projects[tools]})) 👎 -2 (Code-Review) from [Alice Smith]({context.urls.users[alice].reviewer})
 
         > Boo!
 

--- a/tests/features/formatting.feature
+++ b/tests/features/formatting.feature
@@ -34,7 +34,7 @@ Feature: message formatting
       When we check for messages by the bot
       Then there is a message for Alice with the following text:
         """
-        [{context.last_created_change[subject]}]({context.gerrit.http_url}/{context.last_created_change[_number]}) (bob) 👓 Added as reviewer
+        [{context.last_created_change[subject]}]({context.urls.changes[last]}) ([tools]({context.urls.projects[tools]})) by [Bob Jones]({context.urls.users[bob]}) 👓 Added as reviewer
         """
 
   Scenario: inline comments

--- a/tests/features/formatting.feature
+++ b/tests/features/formatting.feature
@@ -14,7 +14,7 @@ Feature: message formatting
       When we check for messages by the bot
       Then there is a message for Bob with the following text:
         """
-        [{context.last_created_change[subject]}]({context.urls.changes[last]}) ([tools]({context.urls.projects[tools]})) 👍 +2 (Code-Review) from [Alice Smith]({context.urls.users[alice].reviewer})
+        [{context.last_created_change[subject]}]({context.urls.changes[last]}) ([tools]({context.urls.projects[tools]})) 👍 +2 (Code-Review) from [Alice Smith]({context.urls.users[alice].reviewer}), 🏁 Submittable
         """
 
   Scenario: review with message
@@ -23,9 +23,29 @@ Feature: message formatting
       When we check for messages by the bot
       Then there is a message for Bob with the following text:
         """
-        [{context.last_created_change[subject]}]({context.urls.changes[last]}) ([tools]({context.urls.projects[tools]})) 👍 +2 (Code-Review) from [Alice Smith]({context.urls.users[alice].reviewer})
+        [{context.last_created_change[subject]}]({context.urls.changes[last]}) ([tools]({context.urls.projects[tools]})) 👍 +2 (Code-Review) from [Alice Smith]({context.urls.users[alice].reviewer}), 🏁 Submittable
 
         > Good job!
+        """
+
+  Scenario: insufficient review without message
+     Given Bob uploads a new change to the tools project
+       And Alice replies to Bob's change with Code-Review+1
+      When we check for messages by the bot
+      Then there is a message for Bob with the following text:
+        """
+        [{context.last_created_change[subject]}]({context.urls.changes[last]}) ([tools]({context.urls.projects[tools]})) 👌 +1 (Code-Review) from [Alice Smith]({context.urls.users[alice].reviewer})
+        """
+
+  Scenario: insufficient review with message
+     Given Bob uploads a new change to the tools project
+       And Alice replies to Bob's change with Code-Review+1 and the comment "Okay job."
+      When we check for messages by the bot
+      Then there is a message for Bob with the following text:
+        """
+        [{context.last_created_change[subject]}]({context.urls.changes[last]}) ([tools]({context.urls.projects[tools]})) 👌 +1 (Code-Review) from [Alice Smith]({context.urls.users[alice].reviewer})
+
+        > Okay job.
         """
 
   Scenario: added as reviewer

--- a/tests/features/formatting.feature
+++ b/tests/features/formatting.feature
@@ -66,8 +66,8 @@ Feature: message formatting
 
         `README`
 
-        > [Line 0]({context.gerrit.http_url}/#/c/{context.last_created_change[_number]}/2/README@0) by alice: You shouldn't be adding this file in the first place.
+        > [Line 0]({context.gerrit.http_url}/#/c/{context.last_created_change[_number]}/2/README@0) by [Alice Smith]({context.urls.users[alice].reviewer}): You shouldn't be adding this file in the first place.
 
-        > [Line 8]({context.gerrit.http_url}/#/c/{context.last_created_change[_number]}/2/README@8) by alice: Who even is Mauris?
+        > [Line 8]({context.gerrit.http_url}/#/c/{context.last_created_change[_number]}/2/README@8) by [Alice Smith]({context.urls.users[alice].reviewer}): Who even is Mauris?
 
         """

--- a/tests/features/gerritbot_behave/format.py
+++ b/tests/features/gerritbot_behave/format.py
@@ -1,0 +1,42 @@
+class URLs:
+    def __init__(self, context):
+        self.projects = ProjectURLs(context)
+        self.users = UserURLs(context)
+        self.changes = ChangeURLs(context)
+
+
+class URLsBase:
+    def __init__(self, context):
+        self.context = context
+
+
+class ProjectURLs(URLsBase):
+    def __getitem__(self, project):
+        return f"{self.context.gerrit_http_url}/q/project:{project}+status:open"
+
+
+class UserURLs(URLsBase):
+    def __getitem__(self, username):
+        return UserURL(self.context, username)
+
+
+class UserURL:
+    def __init__(self, context, username, role="owner"):
+        self.context = context
+        self.username = username
+        self.role = role
+
+    def __str__(self):
+        email = self.context.persons.get(self.username).email
+        return f"{self.context.gerrit_http_url}/q/{self.role}:{email}+status:open"
+
+    def __getattr__(self, role):
+        return type(self)(self.context, self.username, role)
+
+
+class ChangeURLs(URLsBase):
+    def __getitem__(self, change_id):
+        if change_id == "last":
+            change_id = self.context.last_created_change["_number"]
+
+        return f"{self.context.gerrit_http_url}/{change_id}"

--- a/tests/features/steps/bot.py
+++ b/tests/features/steps/bot.py
@@ -75,6 +75,13 @@ def step_impl(context, text):
     assert_that(context.last_matched_message, has_entry("text", contains_string(text)))
 
 
+@then('this message does not include the text "{text}"')
+def step_impl(context, text):
+    assert_that(
+        context.last_matched_message, has_entry("text", is_not(contains_string(text)))
+    )
+
+
 @step("{sender} sends the {command} command to the bot")
 def step_impl(context, sender, command):
     if sender == "everybody":


### PR DESCRIPTION
This is again a bigger PR.  The main concern is moving more of the formatting logic to Lua and making the messages slightly prettier.  Gerrit events are now passed directly to Lua by serializing them.*  

The main gain is dramatically simplifying the formatting logic on the Rust side, see https://github.com/fbenkstein/gerritbot-rs/blob/ce286924f4e9d669e6805e2cda2ed76e2ece37ab/gerritbot/src/format.rs

I you want I can try to make the PR smaller.  However, most of the commits do not make sense on their own so I picked a (hopefully) reasonable subset from my master branch for now.

Fixes #84 
*:  Currently, there's a custom function that serializes to JSON first. There's a more efficient way (that also uses less code) by using the `rlua_serde` which implements serializing to Lua directly.  I will use that as soon as `rlua` 0.16.3 is released.  In my development branch I'm using `rlua` from the master branch. Unfortunately, I cannot make that work with `rlua_serde` because of some package version issues, probably because it's declaring itself as an alpha version.