### PR TITLE
more generic spark messaging API

### DIFF
--- a/gerritbot-spark/examples/echo-bot-sqs.rs
+++ b/gerritbot-spark/examples/echo-bot-sqs.rs
@@ -74,8 +74,8 @@ fn main() {
                 .for_each(move |message| {
                     debug!("got a message: {:?}", message);
                     client
-                        .reply(
-                            &message.person_id,
+                        .send_message(
+                            &message.person_email,
                             &format!("got post:\n```\n{:#?}\n```", message),
                         )
                         .map_err(|e| error!("failed to send message: {}", e))

--- a/gerritbot-spark/examples/echo-bot-sqs.rs
+++ b/gerritbot-spark/examples/echo-bot-sqs.rs
@@ -75,7 +75,7 @@ fn main() {
                     debug!("got a message: {:?}", message);
                     client
                         .send_message(
-                            &message.person_email,
+                            &message.room_id,
                             &format!("got post:\n```\n{:#?}\n```", message),
                         )
                         .map_err(|e| error!("failed to send message: {}", e))

--- a/gerritbot-spark/examples/echo-bot.rs
+++ b/gerritbot-spark/examples/echo-bot.rs
@@ -70,8 +70,8 @@ fn main() {
                 let messages_future = messages.for_each(move |message| {
                     debug!("got a message: {:?}", message);
                     client
-                        .reply(
-                            &message.person_id,
+                        .send_message(
+                            &message.person_email,
                             &format!("got post:\n```\n{:#?}\n```", message),
                         )
                         .map_err(|e| error!("failed to send message: {}", e))

--- a/gerritbot-spark/examples/echo-bot.rs
+++ b/gerritbot-spark/examples/echo-bot.rs
@@ -71,7 +71,7 @@ fn main() {
                     debug!("got a message: {:?}", message);
                     client
                         .send_message(
-                            &message.person_email,
+                            &message.room_id,
                             &format!("got post:\n```\n{:#?}\n```", message),
                         )
                         .map_err(|e| error!("failed to send message: {}", e))

--- a/gerritbot-spark/src/lib.rs
+++ b/gerritbot-spark/src/lib.rs
@@ -183,35 +183,34 @@ pub struct WebhookMessage {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Message {
-    created: Option<Timestamp>,
-    id: MessageId,
+    pub created: Option<Timestamp>,
+    pub id: MessageId,
     pub person_email: Email,
     pub person_id: PersonId,
-    room_id: RoomId,
-    room_type: RoomType,
+    pub room_id: RoomId,
+    pub room_type: RoomType,
 
     // a message contained in a post does not have text loaded
     #[serde(default)]
     pub text: String,
-    markdown: Option<String>,
-    html: Option<String>,
-    files: Option<Vec<String>>,
+    pub markdown: Option<String>,
+    pub html: Option<String>,
+    pub files: Option<Vec<String>>,
 }
 
-impl Message {
-    /// Create a simple message for use in tests.
-    pub fn test_message(person_email: Email, person_id: PersonId, text: String) -> Self {
+impl Default for Message {
+    fn default() -> Self {
         Self {
-            person_email,
-            person_id,
-            text,
-            created: None,
+            created: Default::default(),
+            id: Default::default(),
+            person_email: Default::default(),
+            person_id: Default::default(),
             room_id: Default::default(),
             room_type: RoomType::Direct,
-            html: None,
-            files: None,
-            id: Default::default(),
-            markdown: None,
+            text: Default::default(),
+            markdown: Default::default(),
+            html: Default::default(),
+            files: Default::default(),
         }
     }
 }

--- a/gerritbot-spark/src/lib.rs
+++ b/gerritbot-spark/src/lib.rs
@@ -9,7 +9,6 @@ use futures::sync::mpsc::channel;
 use futures::{IntoFuture as _, Sink, Stream};
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 
 mod sqs;
 
@@ -217,6 +216,61 @@ impl Message {
     }
 }
 
+#[derive(Serialize, Debug, Clone)]
+pub enum CreateMessageTarget<'a> {
+    #[serde(rename = "roomId")]
+    RoomId(&'a RoomIdRef),
+    #[serde(rename = "toPersonId")]
+    PersonId(&'a PersonIdRef),
+    #[serde(rename = "toPersonEmail")]
+    PersonEmail(&'a EmailRef),
+}
+
+impl<'a> From<&'a RoomId> for CreateMessageTarget<'a> {
+    fn from(room_id: &'a RoomId) -> CreateMessageTarget<'a> {
+        CreateMessageTarget::RoomId(room_id)
+    }
+}
+
+impl<'a> From<&'a RoomIdRef> for CreateMessageTarget<'a> {
+    fn from(room_id: &'a RoomIdRef) -> CreateMessageTarget<'a> {
+        CreateMessageTarget::RoomId(room_id)
+    }
+}
+
+impl<'a> From<&'a PersonId> for CreateMessageTarget<'a> {
+    fn from(person_id: &'a PersonId) -> CreateMessageTarget<'a> {
+        CreateMessageTarget::PersonId(person_id)
+    }
+}
+
+impl<'a> From<&'a PersonIdRef> for CreateMessageTarget<'a> {
+    fn from(person_id: &'a PersonIdRef) -> CreateMessageTarget<'a> {
+        CreateMessageTarget::PersonId(person_id)
+    }
+}
+
+impl<'a> From<&'a Email> for CreateMessageTarget<'a> {
+    fn from(email: &'a Email) -> CreateMessageTarget<'a> {
+        CreateMessageTarget::PersonEmail(email)
+    }
+}
+
+impl<'a> From<&'a EmailRef> for CreateMessageTarget<'a> {
+    fn from(email: &'a EmailRef) -> CreateMessageTarget<'a> {
+        CreateMessageTarget::PersonEmail(email)
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateMessageParameters<'a> {
+    #[serde(flatten)]
+    target: CreateMessageTarget<'a>,
+    text: Option<&'a str>,
+    markdown: Option<&'a str>,
+}
+
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct PersonDetails {
@@ -398,7 +452,7 @@ impl Client {
             .post(&format!("{}/{}", self.url, resource))
             .bearer_auth(&self.bot_token)
             .header(http::header::ACCEPT, "application/json")
-            .json(&data)
+            .json(data)
             .send()
             .from_err()
             .map(|_| ())
@@ -474,13 +528,40 @@ impl Client {
         &self.bot_id
     }
 
-    pub fn reply(&self, person_id: &PersonId, msg: &str) -> impl Future<Item = (), Error = Error> {
-        let json = json!({
-            "toPersonId": person_id,
-            "markdown": msg,
-        });
-        debug!("send message to {}", person_id);
-        self.api_post_json("messages", &json)
+    pub fn reply<'a>(
+        &self,
+        person_id: &'a PersonIdRef,
+        msg: &'a str,
+    ) -> impl Future<Item = (), Error = Error> {
+        self.send_message(person_id, msg)
+    }
+
+    pub fn send_message<'a, T: ?Sized>(
+        &self,
+        target: &'a T,
+        markdown: &'a str,
+    ) -> impl Future<Item = (), Error = Error>
+    where
+        &'a T: Into<CreateMessageTarget<'a>>,
+    {
+        self.create_message(CreateMessageParameters {
+            target: target.into(),
+            markdown: Some(markdown),
+            text: None,
+        })
+    }
+
+    pub fn create_message<'a>(
+        &self,
+        parameters: CreateMessageParameters<'a>,
+    ) -> impl Future<Item = (), Error = Error> {
+        debug!("send message to {:?}", parameters.target);
+        let json = match serde_json::to_value(&parameters) {
+            Ok(json) => json,
+            Err(e) => return future::Either::A(future::err(e).from_err()),
+        };
+
+        future::Either::B(self.api_post_json("messages", &json))
     }
 
     pub fn get_message(

--- a/gerritbot-spark/src/lib.rs
+++ b/gerritbot-spark/src/lib.rs
@@ -265,9 +265,11 @@ impl<'a> From<&'a EmailRef> for CreateMessageTarget<'a> {
 #[serde(rename_all = "camelCase")]
 pub struct CreateMessageParameters<'a> {
     #[serde(flatten)]
-    target: CreateMessageTarget<'a>,
-    text: Option<&'a str>,
-    markdown: Option<&'a str>,
+    pub target: CreateMessageTarget<'a>,
+    pub text: Option<&'a str>,
+    pub markdown: Option<&'a str>,
+    /// Note: This parameter is not in the documented API.
+    pub html: Option<&'a str>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -539,6 +541,7 @@ impl Client {
             target: target.into(),
             markdown: Some(markdown),
             text: None,
+            html: None,
         })
     }
 

--- a/gerritbot-spark/src/lib.rs
+++ b/gerritbot-spark/src/lib.rs
@@ -528,14 +528,6 @@ impl Client {
         &self.bot_id
     }
 
-    pub fn reply<'a>(
-        &self,
-        person_id: &'a PersonIdRef,
-        msg: &'a str,
-    ) -> impl Future<Item = (), Error = Error> {
-        self.send_message(person_id, msg)
-    }
-
     pub fn send_message<'a, T: ?Sized>(
         &self,
         target: &'a T,

--- a/gerritbot/examples/gerritbot-console.rs
+++ b/gerritbot/examples/gerritbot-console.rs
@@ -93,7 +93,12 @@ impl Into<spark::Message> for SimpleInputMessage {
             text,
         } = self;
         let person_id = person_id.unwrap_or_else(|| email_to_person_id(&person_email));
-        spark::Message::test_message(person_email, person_id, text)
+        spark::Message {
+            person_email,
+            person_id,
+            text,
+            ..Default::default()
+        }
     }
 }
 
@@ -214,11 +219,12 @@ fn main() {
                 .ok()
         } else if let Some(email) = &email {
             // If we have an email, send each line from this email.
-            Some(spark::Message::test_message(
-                spark::Email::new(email.clone()),
-                spark::PersonId::new(email.clone()),
-                line,
-            ))
+            Some(spark::Message {
+                person_email: spark::Email::new(email.clone()),
+                person_id: spark::PersonId::new(email.clone()),
+                text: line,
+                ..Default::default()
+            })
         } else {
             // If no email was given, parse it from each line.
             lazy_static! {
@@ -231,11 +237,12 @@ fn main() {
                 .map(|captures| {
                     let email = captures.name("email").unwrap().as_str();
                     let message = captures.name("message").unwrap().as_str();
-                    spark::Message::test_message(
-                        spark::Email::new(email.to_string()),
-                        spark::PersonId::new(email.to_string()),
-                        message.to_string(),
-                    )
+                    spark::Message {
+                        person_email: spark::Email::new(email.to_string()),
+                        person_id: spark::PersonId::new(email.to_string()),
+                        text: message.to_string(),
+                        ..Default::default()
+                    }
                 })
                 .or_else(|| {
                     warn!(r#"input not understood: please send as "<email>: <message>""#);

--- a/gerritbot/examples/gerritbot-console.rs
+++ b/gerritbot/examples/gerritbot-console.rs
@@ -112,7 +112,7 @@ enum ConsoleSparkClient {
 
 impl bot::SparkClient for ConsoleSparkClient {
     type ReplyFuture = future::FutureResult<(), spark::Error>;
-    fn reply(&self, person_id: &spark::PersonId, msg: &str) -> Self::ReplyFuture {
+    fn send_message(&self, person_id: &spark::PersonId, msg: &str) -> Self::ReplyFuture {
         // Write synchronously and crash if writing fails. There's no point in
         // error handling here.
         match self {

--- a/gerritbot/src/lib.rs
+++ b/gerritbot/src/lib.rs
@@ -63,13 +63,13 @@ impl GerritCommandRunner for gerrit::CommandRunner {}
 
 pub trait SparkClient: Clone {
     type ReplyFuture: Future<Item = (), Error = spark::Error> + Send;
-    fn reply(&self, person_id: &spark::PersonId, msg: &str) -> Self::ReplyFuture;
+    fn send_message(&self, person_id: &spark::PersonId, msg: &str) -> Self::ReplyFuture;
 }
 
 impl SparkClient for spark::Client {
     type ReplyFuture = Box<dyn Future<Item = (), Error = spark::Error> + Send>;
-    fn reply(&self, person_id: &spark::PersonId, msg: &str) -> Self::ReplyFuture {
-        Box::new(self.reply(person_id, msg))
+    fn send_message(&self, person_id: &spark::PersonId, msg: &str) -> Self::ReplyFuture {
+        Box::new(self.send_message(person_id, msg))
     }
 }
 
@@ -427,7 +427,7 @@ where
             .for_each(move |response| {
                 debug!("Replying with: {}", response.message);
                 spark_client
-                    .reply(&response.person_id, &response.message)
+                    .send_message(&response.person_id, &response.message)
                     .map_err(|e| error!("failed to send spark message: {}", e))
             })
     }
@@ -847,7 +847,7 @@ mod test {
 
     impl SparkClient for TestSparkClient {
         type ReplyFuture = future::FutureResult<(), spark::Error>;
-        fn reply(&self, _person_id: &PersonId, _msg: &str) -> Self::ReplyFuture {
+        fn send_message(&self, _person_id: &PersonId, _msg: &str) -> Self::ReplyFuture {
             future::ok(())
         }
     }

--- a/gerritbot/tests/test_command.rs
+++ b/gerritbot/tests/test_command.rs
@@ -31,7 +31,7 @@ struct TestSparkClient {
 
 impl SparkClient for TestSparkClient {
     type ReplyFuture = future::FutureResult<(), spark::Error>;
-    fn reply(&self, person_id: &PersonId, msg: &str) -> Self::ReplyFuture {
+    fn send_message(&self, person_id: &PersonId, msg: &str) -> Self::ReplyFuture {
         self.replies.borrow_mut().push(Reply {
             person_id: person_id.to_owned(),
             message: msg.to_string(),

--- a/gerritbot/tests/test_command.rs
+++ b/gerritbot/tests/test_command.rs
@@ -66,12 +66,11 @@ impl TestBotTrait for TestBot {
     }
 
     fn send_messages(self, messages: &[&str]) {
-        let spark_messages = stream::iter_ok(messages.iter().map(|msg| {
-            spark::Message::test_message(
-                TEST_PERSON_EMAIL.to_owned(),
-                TEST_PERSON_ID.to_owned(),
-                msg.to_string(),
-            )
+        let spark_messages = stream::iter_ok(messages.iter().map(|msg| spark::Message {
+            person_email: TEST_PERSON_EMAIL.to_owned(),
+            person_id: TEST_PERSON_ID.to_owned(),
+            text: msg.to_string(),
+            ..Default::default()
         }));
         let gerrit_events = stream::empty();
         self.run(gerrit_events, spark_messages).wait().unwrap();


### PR DESCRIPTION
Rename `reply` to`send_message` and allow sending to rooms and email addresses instead of just person ids.  Add `create_message` function to allow setting `text` and `markdown` (and undocumented `html`) attributes of a message explicitely.  Add proper echoing to echo-bots